### PR TITLE
Add Google Maps CLI builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 
 ## Adding a new builder
 
-1. Find the `buidlers.json` in `assets` folder.
+1. Find the `builders.json` in `assets` folder.
 2. Provide the data for new builder in below `json` format
 
 ```json

--- a/src/assets/builders.json
+++ b/src/assets/builders.json
@@ -54,9 +54,14 @@
     "description": "Remove files and folders from your project. Useful for removing any assets you don't want in a production build.",
     "repository": "https://github.com/BojanKogoj/ng-builder-file-remover"
   },
-    {
+  {
     "name": "@netlify-builder/deploy",
     "description": "Deploy your application on Netlify with Angular CLI<br><ul><li>ng add @netlify-build/deploy</li><li>ng deploy</li></ul>.",
     "repository": "https://github.com/ngx-builders/netlify-builder"
+  },
+  {
+    "name": "ng-builder-google-maps",
+    "description": "Angular CLI builder that adds the Google Maps API into your Angular application.",
+    "repository": "https://github.com/Developer-Plexscape/ng-builder-google-maps"
   }
 ]


### PR DESCRIPTION
Add `ng-builder-google-maps` repository to the list of available Angular builders.